### PR TITLE
Intorduce codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Owners
+* @thepetk @lysnikolaou @StaVergos @gzisopoulos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @thepetk @lysnikolaou @StaVergos @gzisopoulos
+* @pygreece @thepetk @lysnikolaou @StaVergos @gzisopoulos


### PR DESCRIPTION
Simply updates the CODEOWNERS with the global codeowners of the discord repo.