### PR TITLE
Add sync text and health slash commands to verify health status

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -10,9 +10,10 @@ async def main() -> None:
     """Main function to run the bot."""
     intents = discord.Intents.default()
     intents.members = True
+    intents.message_content = True
 
     discord.utils.setup_logging()
-    bot = commands.Bot(command_prefix="/", intents=intents)
+    bot = commands.Bot(command_prefix="!", intents=intents)
     await bot.add_cog(cog.WelcomeAndCoC(bot))
     await bot.start(config.DISCORD_TOKEN)
 

--- a/bot/cog.py
+++ b/bot/cog.py
@@ -1,7 +1,9 @@
+import datetime
 import logging
 
 import discord
 from discord.ext import commands
+from sqlalchemy import select
 
 from bot import config, db
 from bot.exceptions import WrongGuildException, WrongUserException
@@ -34,6 +36,7 @@ class WelcomeAndCoC(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         """Initialize the cog with the bot instance."""
         self.bot = bot
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
@@ -148,3 +151,51 @@ class WelcomeAndCoC(commands.Cog):
             db_member.reacted = True
             session.add(db_member)
         logger.info(f"Updated reacted=True for {member.name} ({member.id}) in database.")
+
+    @commands.command()
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    async def sync(self, ctx: commands.Context[commands.Bot]) -> None:
+        """Sync the command tree with the guild."""
+        logger.info("Received sync command.")
+        assert ctx.guild is not None
+        self.bot.tree.copy_global_to(guild=discord.Object(ctx.guild.id))
+        await self.bot.tree.sync(guild=discord.Object(ctx.guild.id))
+        await ctx.reply("Command tree synced.")
+
+    @commands.hybrid_command()  # type: ignore
+    @commands.guild_only()
+    @commands.has_role("pygreece organizers")
+    async def health(self, ctx: commands.Context[commands.Bot]) -> None:
+        """Send the bot's health status."""
+        logger.info("Received health check command.")
+
+        embed = discord.Embed(
+            title="Bot Health Status",
+            color=discord.Color.blue(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+        )
+
+        # Discord connection
+        latency = round(self.bot.latency * 1000)
+        embed.add_field(name="Discord Connection", value=f"Latency: {latency}ms", inline=False)
+
+        # Database connection
+        try:
+            async with db.get_session() as session:
+                # Simple query to test connection
+                await session.execute(select(1))
+                embed.add_field(name="Database Connection", value="✅ Connected", inline=False)
+        except Exception as e:
+            embed.add_field(name="Database Connection", value=f"❌ Error: {str(e)}", inline=False)
+
+        # Uptime
+        uptime = datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        days, remainder = divmod(int(uptime.total_seconds()), 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        uptime_str = f"{days}d {hours}h {minutes}m {seconds}s"
+        embed.add_field(name="Uptime", value=uptime_str, inline=False)
+
+        await ctx.send(embed=embed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 import pytest_asyncio
+from discord.ext import commands
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -13,6 +14,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from bot import config
+from bot.cog import WelcomeAndCoC
 from bot.models import Base
 
 
@@ -118,3 +120,26 @@ def mock_reaction_payload(
     payload.emoji = MagicMock(spec=discord.Emoji)
     payload.emoji.name = "✅"
     return payload
+
+
+@pytest.fixture
+def mock_bot() -> MagicMock:
+    """Create a mock Discord bot."""
+    bot = MagicMock(spec=commands.Bot)
+    bot.latency = 0.05  # Simulate a latency of 50ms
+    return bot
+
+
+@pytest.fixture
+def mock_cog(mock_bot: MagicMock) -> WelcomeAndCoC:
+    """Create a mock instance of the WelcomeAndCoC cog."""
+    cog = WelcomeAndCoC(mock_bot)
+    return cog
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    """Create a mock Discord context."""
+    context = MagicMock(spec=commands.Context)
+    context.send = AsyncMock()
+    return context

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -58,7 +58,7 @@ async def test_bot_initialization(
     # Verify bot was initialized correctly
     mock_bot_class.assert_called_once()
     _, kwargs = mock_bot_class.call_args
-    assert kwargs["command_prefix"] == "/"
+    assert kwargs["command_prefix"] == "!"
     assert kwargs["intents"] == mock_intents_instance
 
     # Verify the cog was initialized with the bot instance


### PR DESCRIPTION
## What does this PR do?

- Add `health` slash command to be able to verify that bot is running.
- Add `sync` text command to register slash commands with servers when they're changing.
