### PR TITLE
bugfix new members not getting a button with their ticket message

### DIFF
--- a/bot/ticket_cog.py
+++ b/bot/ticket_cog.py
@@ -38,6 +38,7 @@ class TicketVerification(commands.Cog):
             member,
             messages.NEW_MEMBER_TICKET_MESSAGE.format(name=member.mention),
             f"private {config.TICKET_THREAD_PREFIX} thread",
+            view=TicketView(member._user),
         )
 
     @commands.Cog.listener()


### PR DESCRIPTION
## What does this PR do?
Fixes new members not getting a button with their ticket message