### PR TITLE
Make it so that users that are already community members can react

### DIFF
--- a/bot/roles.py
+++ b/bot/roles.py
@@ -15,7 +15,7 @@ async def assign_role(member: discord.Member, role_name: str) -> bool:
     :param discord.Member member: The member to assign the role to.
     :param str role_name: The name of the role to assign.
 
-    :returns bool: True if the role was assigned, False otherwise.
+    :returns bool: True if the role was assigned or the member already has the role, False otherwise.
     """
 
     # Assign the "role_name" role
@@ -26,7 +26,7 @@ async def assign_role(member: discord.Member, role_name: str) -> bool:
         return False
     if role in member.roles:
         logger.info(f"{member.name} ({member.id}) already has the '{role.name}' role.")
-        return False
+        return True
 
     try:
         await member.add_roles(role)

--- a/bot/welcome_and_coc_cog.py
+++ b/bot/welcome_and_coc_cog.py
@@ -109,15 +109,16 @@ class WelcomeAndCoC(commands.Cog):
             db_member, _ = await Member.get_or_create(id=member.id, session=session)
             if db_member.reacted:
                 logger.info("Member already reacted to CoC message.")
-                return
-
-            db_member.reacted = True
-            try:
-                session.add(db_member)
-                logger.info(f"Updated reacted=True for {member.name} ({member.id}) in database.")
-            except Exception as e:
-                logger.error(f"Error updating reacted for {member.name} ({member.id}): {e}")
-                return
+            else:
+                db_member.reacted = True
+                try:
+                    session.add(db_member)
+                    logger.info(
+                        f"Updated reacted=True for {member.name} ({member.id}) in database."
+                    )
+                except Exception as e:
+                    logger.error(f"Error updating reacted for {member.name} ({member.id}): {e}")
+                    return
 
         self.bot.dispatch("new_member_reacted_to_coc", member)
 


### PR DESCRIPTION
## What does this PR do?

- Make it so members that already have the role `Community Member` can react to the CoC message and their response gets recorded. In short, make `on_member_reacted_to_coc` idempotent.